### PR TITLE
Bugfix 2.3

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,10 @@
+From QOL 2.2 to bugfix 2.3:
+
+Bugfixes:
+- Darn errors! (Making the script that updates the help file into a function made it so that the "chatCommandsHelp" (and the admin and root variations) variable weren't actually written
+
+--------------------------------------------------
+
 From QOL 2.1 to QOL 2.2:
 
 Additions:

--- a/RunServer.py
+++ b/RunServer.py
@@ -521,6 +521,7 @@ chatCommandsLastUsed = {}
 
 #   Help variables (help text keys in-game will be organized by the order by they are defined)
 def updateHelp():
+    global chatCommandsHelp,chatCommandsHelpAdmin,chatCommandsHelpRoot
     rewriteHelp = False
     if not os.path.exists(cacheDir+'help/'): os.mkdir(cacheDir+'help/') #Create help cache directory if it doesn't exist
     if not os.path.exists(cacheDir+'help/version.txt'): #Create help version file if it doesn't exist


### PR DESCRIPTION
From QOL 2.2 to bugfix 2.3:

Bugfixes:
- Darn errors! (Making the script that updates the help file into a function made it so that the "chatCommandsHelp" (and the admin and root variations) variable weren't actually written